### PR TITLE
Add CashOut to MyPortfolio

### DIFF
--- a/src/components/CashOut.js
+++ b/src/components/CashOut.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { Collapse } from 'reactstrap';
 import CashOutFormContainer from './CashOutFormContainer';
 import { getUserBalance } from '../actions/userActions';
-import { Wrapped, web3 } from '../ethereum';
 
 // Use named export for unconnected component for testing
 export class CashOut extends Component {
@@ -14,6 +13,8 @@ export class CashOut extends Component {
       formOpen: false,
       resultsMessage: ''
     };
+
+    this.toggleFormVisibility = this.toggleFormVisibility.bind(this);
   }
 
   async componentWillMount() {
@@ -44,11 +45,12 @@ export class CashOut extends Component {
   render() {
     return (
       <div className="container">
-        <div className="user-balance">
-          Your Balance: {this.props.userBalance}
-        </div>
+        <h3 className="user-balance">Your Balance: {this.props.userBalance}</h3>
         <div id="cashout-button">
-          <button className="btn btn-info" onClick={this.toggleFormVisibility}>
+          <button
+            className="btn create-contract-btn"
+            onClick={this.toggleFormVisibility}
+          >
             Cash Out
           </button>
         </div>
@@ -72,7 +74,7 @@ export class CashOut extends Component {
 CashOut.propTypes = {
   getUserBalance: PropTypes.func.isRequired,
   userBalance: PropTypes.number.isRequired,
-  cashOutTx: PropTypes.string.isRequired,
+  cashOutTx: PropTypes.string,
   cashOutError: PropTypes.string
 };
 

--- a/src/components/CashOutFormComponent.js
+++ b/src/components/CashOutFormComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Field } from 'redux-form';
-import { InputGroup } from 'reactstrap';
+import { InputGroup, InputGroupAddon } from 'reactstrap';
 import InputNumber from './InputNumber';
 
 export const CashOutFormComponent = ({
@@ -11,7 +11,6 @@ export const CashOutFormComponent = ({
 }) => {
   return (
     <div>
-      <h3>CashOut Order</h3>
       <form onSubmit={handleSubmit(onSubmit)}>
         <InputGroup>
           <Field
@@ -23,7 +22,7 @@ export const CashOutFormComponent = ({
         </InputGroup>
 
         <div>
-          <button type="submit" className="btn btn-primary">
+          <button type="submit" className="btn btn-primary btn-lg">
             Submit
           </button>
         </div>

--- a/src/components/CashOutFormContainer.js
+++ b/src/components/CashOutFormContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { reduxForm, getFormValues } from 'redux-form';
-import { sendCashOutRequest } from '../actions/orderActions';
+import { sendCashOutRequest } from '../actions/userActions';
 import CashOutFormComponent from './CashOutFormComponent';
 
 export let CashOutFormContainer = props => {
@@ -22,7 +22,7 @@ export let CashOutFormContainer = props => {
 };
 
 CashOutFormComponent.propTypes = {
-  sendCashOutRequest: PropTypes.func.isRequired,
+  // sendCashOutRequest: PropTypes.func.isRequired,
   formValues: PropTypes.object,
   userOrders: PropTypes.array
 };

--- a/src/components/MyPortfolio.js
+++ b/src/components/MyPortfolio.js
@@ -5,7 +5,8 @@ import { Collapse } from 'reactstrap';
 import MyPositions from './MyPositions';
 import MyTransactions from './MyTransactions';
 import ContractDetails from './ContractDetails';
-import CreateContract from "./CreateContract";
+import CreateContract from './CreateContract';
+import CashOut from './CashOut';
 import {
   getUserAccount,
   getUserPositions,
@@ -20,7 +21,7 @@ export class MyPortfolio extends Component {
 
     this.state = {
       detailsOpen: false,
-      formOpen: false,
+      formOpen: false
     };
   }
 
@@ -37,12 +38,12 @@ export class MyPortfolio extends Component {
   //
   handleRowClick = async (transactionAddress, e) => {
     e.preventDefault();
-    console.log('ROW CLICK', transactionAddress)
+    console.log('ROW CLICK', transactionAddress);
     // TODO: Do we need a Transaction Details popup?
     // this.openContractDetails(symbol);
   };
   //
-  openContractDetails = async (symbol) => {
+  openContractDetails = async symbol => {
     // await this.props.getContractDetails(symbol);
     this.setState({
       detailsOpen: true
@@ -59,18 +60,16 @@ export class MyPortfolio extends Component {
       formOpen: !this.state.formOpen
     });
   };
-  renderCreateContract = () =>{
-    return this.state.formOpen?(
+  renderCreateContract = () => {
+    return this.state.formOpen ? (
       <CreateContract close={this.closeCreateContract} />
-    ):(
-      null
-    )
-  }
-  closeCreateContract = () =>{
+    ) : null;
+  };
+  closeCreateContract = () => {
     this.setState({
       formOpen: false
     });
-  }
+  };
   render() {
     return (
       <div id="portfolio">
@@ -80,7 +79,13 @@ export class MyPortfolio extends Component {
           <ContractDetails onClick={this.closeContractDetails.bind(this)} />
         </Collapse>
         {this.renderCreateContract()}
-        <div className="create-contract-btn" onClick={this.handleCreateContract}>Create Contract</div>
+        <div
+          className="create-contract-btn"
+          onClick={this.handleCreateContract}
+        >
+          Create Contract
+        </div>
+        <CashOut />
       </div>
     );
   }


### PR DESCRIPTION
Note: There's a problem with sendCashOutRequest in CashOutFormContainer. It should be showing up a prop. It's wired up exactly like the other forms, but comes back undefined. I've checked all the variable names at least half a dozen times and can't find any typos. I commented out sendCashOutRequest from the propTypes list because it's throwing a console error. I'll test the sendCashOutRequest action creator and see if the problem originates there.

Included:
- Added CashOut in MyPortfolio

Affects:
```
src/components/CashOut.js
src/components/CashOutFormComponent.js
src/components/CashOutFormContainer.js
src/components/MyPortfolio.js
```